### PR TITLE
2d quiver plots have arrowheads

### DIFF
--- a/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
@@ -89,8 +89,8 @@ end
 %-------------------------------------------------------------------------%
 
 %-quiver barbs-%
-max_head_size = 0.15; % 'MaxHeadSize' scalar, matlab clips to 0.2
-head_width = deg2rad(15); % barb width, not supported by matlab
+max_head_size = 0.3; % 'MaxHeadSize' scalar, matlab clips to 0.2
+head_width = deg2rad(17); % barb width, not supported by matlab
 for n = 1:length(xdata) % xdata and ydata had better be the same length... throw an exception if this isn't true?
     % length of arrow
     l = norm([0.1*udata(n), 0.1*vdata(n)]);
@@ -100,9 +100,9 @@ for n = 1:length(xdata) % xdata and ydata had better be the same length... throw
     
     % make barb with specified angular width and length prop. to arrow
     barb = [...
-    [-0.5*l*cos(head_width), 0.5*l*sin(head_width)]; ... 
+    [-max_head_size*l*cos(head_width), max_head_size*l*sin(head_width)]; ... 
     [0, 0]; ...  
-    [-0.5*l*cos(head_width), -0.5*l*sin(head_width)];
+    [-max_head_size*l*cos(head_width), -max_head_size*l*sin(head_width)];
     ]';
     
     % affine matrix: rotate by arrow angle and translate to end of arrow

--- a/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
@@ -89,39 +89,41 @@ end
 %-------------------------------------------------------------------------%
 
 %-quiver barbs-%
-% 'MaxHeadSize' scalar, matlab clips to 0.2 in r2014b
-maxheadsize = quiver_data.MaxHeadSize;
-% barb angular width, not supported by matlab
-head_width = deg2rad(17.5); 
-for n = 1:length(xdata)
-    % length of arrow
-    l = norm([0.1*udata(n), 0.1*vdata(n)]);
-    
-    % angle of arrow
-    phi = atan2(vdata(n),udata(n));
-    
-    % make barb with specified angular width, length is prop. to arrow
-    barb = [...
-    [-maxheadsize*l*cos(head_width), maxheadsize*l*sin(head_width)]; ... 
-    [0, 0]; ...  
-    [-maxheadsize*l*cos(head_width), -maxheadsize*l*sin(head_width)]; ...
-    [nan, nan]; ...
-    ]';
-    
-    % affine matrix: rotate by arrow angle and translate to end of arrow
-    barb_transformation = affine2d([...
-        [cos(phi), sin(phi), 0]; ...
-        [-sin(phi), cos(phi), 0]; ...
-        [xdata(n) + 0.1*udata(n), ydata(n) + 0.1*vdata(n), 1];
-        ]);
-    
-    % place barb at end of arrow
-    barb = transformPointsForward(barb_transformation, barb')';
-    
-    % add barb to plot data, inserting is optimized in matlab >2010
-    for col = 1:4
-        obj.data{quiverIndex}.x(end+1) = barb(1,col); % point 1
-        obj.data{quiverIndex}.y(end+1) = barb(2,col);
+if isHG2()
+    % 'MaxHeadSize' scalar, matlab clips to 0.2 in r2014b
+    maxheadsize = quiver_data.MaxHeadSize;
+    % barb angular width, not supported by matlab
+    head_width = deg2rad(17.5);
+    for n = 1:length(xdata)
+        % length of arrow
+        l = norm([0.1*udata(n), 0.1*vdata(n)]);
+        
+        % angle of arrow
+        phi = atan2(vdata(n),udata(n));
+        
+        % make barb with specified angular width, length is prop. to arrow
+        barb = [...
+            [-maxheadsize*l*cos(head_width), maxheadsize*l*sin(head_width)]; ...
+            [0, 0]; ...
+            [-maxheadsize*l*cos(head_width), -maxheadsize*l*sin(head_width)]; ...
+            [nan, nan]; ...
+            ]';
+        
+        % affine matrix: rotate by arrow angle and translate to end of arrow
+        barb_transformation = affine2d([...
+            [cos(phi), sin(phi), 0]; ...
+            [-sin(phi), cos(phi), 0]; ...
+            [xdata(n) + 0.1*udata(n), ydata(n) + 0.1*vdata(n), 1];
+            ]);
+        
+        % place barb at end of arrow
+        barb = transformPointsForward(barb_transformation, barb')';
+        
+        % add barb to plot data, inserting is optimized in matlab >2010
+        for col = 1:4
+            obj.data{quiverIndex}.x(end+1) = barb(1,col); % point 1
+            obj.data{quiverIndex}.y(end+1) = barb(2,col);
+        end
     end
 end
 

--- a/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
@@ -89,20 +89,23 @@ end
 %-------------------------------------------------------------------------%
 
 %-quiver barbs-%
-maxheadsize = quiver_data.MaxHeadSize; % 'MaxHeadSize' scalar, matlab clips to 0.2
-head_width = deg2rad(17); % barb width, not supported by matlab
-for n = 1:length(xdata) % xdata and ydata had better be the same length... throw an exception if this isn't true?
+% 'MaxHeadSize' scalar, matlab clips to 0.2 in r2014b
+maxheadsize = quiver_data.MaxHeadSize;
+% barb angular width, not supported by matlab
+head_width = deg2rad(17.5); 
+for n = 1:length(xdata)
     % length of arrow
     l = norm([0.1*udata(n), 0.1*vdata(n)]);
     
     % angle of arrow
     phi = atan2(vdata(n),udata(n));
     
-    % make barb with specified angular width and length prop. to arrow
+    % make barb with specified angular width, length is prop. to arrow
     barb = [...
     [-maxheadsize*l*cos(head_width), maxheadsize*l*sin(head_width)]; ... 
     [0, 0]; ...  
-    [-maxheadsize*l*cos(head_width), -maxheadsize*l*sin(head_width)];
+    [-maxheadsize*l*cos(head_width), -maxheadsize*l*sin(head_width)]; ...
+    [nan, nan]; ...
     ]';
     
     % affine matrix: rotate by arrow angle and translate to end of arrow
@@ -112,18 +115,14 @@ for n = 1:length(xdata) % xdata and ydata had better be the same length... throw
         [xdata(n) + 0.1*udata(n), ydata(n) + 0.1*vdata(n), 1];
         ]);
     
-    % apply transformation to barb
+    % place barb at end of arrow
     barb = transformPointsForward(barb_transformation, barb')';
     
-    % add barb to plot data
-    obj.data{quiverIndex}.x(end+1) = barb(1,1); % point 1
-    obj.data{quiverIndex}.y(end+1) = barb(2,1);
-    obj.data{quiverIndex}.x(end+1) = barb(1,2); % point 2
-    obj.data{quiverIndex}.y(end+1) = barb(2,2);
-    obj.data{quiverIndex}.x(end+1) = barb(1,3); % point 3
-    obj.data{quiverIndex}.y(end+1) = barb(2,3);
-    obj.data{quiverIndex}.x(end+1) = nan; % insert blank line between successive barbs
-    obj.data{quiverIndex}.y(end+1) = nan;
+    % add barb to plot data, inserting is optimized in matlab >2010
+    for col = 1:4
+        obj.data{quiverIndex}.x(end+1) = barb(1,col); % point 1
+        obj.data{quiverIndex}.y(end+1) = barb(2,col);
+    end
 end
 
 %-------------------------------------------------------------------------%

--- a/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
@@ -65,6 +65,12 @@ udata = reshape(quiver_data.UData,1,size(quiver_data.UData,1)*size(quiver_data.U
 vdata = reshape(quiver_data.VData,1,size(quiver_data.VData,1)*size(quiver_data.VData,1)); 
 
 %------------------------------------------------------------------------%
+% JNJ: Need to implement the arrowheads!!! Bit of an oversight...!
+% Also, compare Python plotly arrowheads to the matlab arrowheads...
+% At the same time, we might make sure the line length adjusts
+% appropriately.
+% Might as well make arrowheads scaleable, too.
+%------------------------------------------------------------------------%
 
 %-quiver x-%
 m = 1; 

--- a/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
@@ -89,7 +89,7 @@ end
 %-------------------------------------------------------------------------%
 
 %-quiver barbs-%
-max_head_size = 0.3; % 'MaxHeadSize' scalar, matlab clips to 0.2
+maxheadsize = quiver_data.MaxHeadSize; % 'MaxHeadSize' scalar, matlab clips to 0.2
 head_width = deg2rad(17); % barb width, not supported by matlab
 for n = 1:length(xdata) % xdata and ydata had better be the same length... throw an exception if this isn't true?
     % length of arrow
@@ -100,9 +100,9 @@ for n = 1:length(xdata) % xdata and ydata had better be the same length... throw
     
     % make barb with specified angular width and length prop. to arrow
     barb = [...
-    [-max_head_size*l*cos(head_width), max_head_size*l*sin(head_width)]; ... 
+    [-maxheadsize*l*cos(head_width), maxheadsize*l*sin(head_width)]; ... 
     [0, 0]; ...  
-    [-max_head_size*l*cos(head_width), -max_head_size*l*sin(head_width)];
+    [-maxheadsize*l*cos(head_width), -maxheadsize*l*sin(head_width)];
     ]';
     
     % affine matrix: rotate by arrow angle and translate to end of arrow


### PR DESCRIPTION
Fixes #69 

    [x,y] = meshgrid(0:0.2:2,0:0.2:2);
    u = cos(x).*y;
    v = sin(x).*y;
    quiver(x,y,u,v, 'MaxHeadSize',0.3)
    fig2plotly()
See https://plot.ly/~jnj.16180340/514/
<div>
    <a href="https://plot.ly/~jnj.16180340/514/" target="_blank" title="&lt;b&gt;&lt;b&gt;&lt;/b&gt;&lt;/b&gt;" style="display: block; text-align: center;"><img src="https://plot.ly/~jnj.16180340/514.png" alt="&lt;b&gt;&lt;b&gt;&lt;/b&gt;&lt;/b&gt;" style="max-width: 100%;width: 831px;"  width="831" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
    <script data-plotly="jnj.16180340:514"  src="https://plot.ly/embed.js" async></script>
</div>
